### PR TITLE
Added docker functionality. Only tested on Ubuntu 24.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**
+!docker/
+!ms_mapping/

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+*.pyc
+**/__pycache__/
+.vscode/
+data/
+bags/
+
+

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -1,0 +1,17 @@
+services:
+  msmapping:
+    build:
+      context: ..
+      dockerfile: docker/dockerfile
+    image: ms_mapping
+    container_name: ms_mapping
+    volumes:
+      - ../:/root/catkin_ws/src/ms_mapping/
+      - /tmp/.X11-unix:/tmp/.X11-unix # Needed to display RViz within the container
+    environment:
+      DISPLAY: "${DISPLAY}"
+    working_dir: /root/catkin_ws
+    network_mode: host
+    stdin_open: true
+    tty: true
+    

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -7,9 +7,11 @@ services:
     container_name: ms_mapping
     volumes:
       - ../:/root/catkin_ws/src/ms_mapping/
+      - ${HOME}/yride_env_setup:/yride_env_setup:ro # Take out
       - /tmp/.X11-unix:/tmp/.X11-unix # Needed to display RViz within the container
     environment:
       DISPLAY: "${DISPLAY}"
+      CONTAINER_NAME: msmapping # Take out
     working_dir: /root/catkin_ws
     network_mode: host
     stdin_open: true

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -1,0 +1,101 @@
+# Start from a ROS Noetic base image.
+FROM ros:noetic
+
+# Install common build tools and necessary dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    cmake \
+    git \
+    curl \
+    xz-utils \
+    libgoogle-glog-dev \
+    libgflags-dev \
+    libatlas-base-dev \
+    libceres-dev \
+    libboost-all-dev \
+    libeigen3-dev \
+    libpcl-dev \
+    libopencv-dev \
+    libxml2-dev \
+    libyaml-cpp-dev \
+    python3-dev \
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Install ROS Dependencies ---
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ros-noetic-geometry-msgs \
+    ros-noetic-nav-msgs \
+    ros-noetic-sensor-msgs \
+    ros-noetic-roscpp \
+    ros-noetic-rospy \
+    ros-noetic-rosbag \
+    ros-noetic-std-msgs \
+    ros-noetic-image-transport \
+    ros-noetic-cv-bridge \
+    ros-noetic-tf \
+    ros-noetic-message-generation \
+    ros-noetic-catkin \
+    ros-noetic-rviz \
+    ros-noetic-jsk-rviz-plugins \
+    python3-catkin-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# --- Update CMake ---
+# Download and install a newer CMake
+ARG CMAKE_VERSION="3.25.0"
+RUN CMAKE_MAJOR_MINOR=$(echo ${CMAKE_VERSION} | cut -d. -f1-2) && \
+    curl -sL https://cmake.org/files/v${CMAKE_MAJOR_MINOR}/cmake-${CMAKE_VERSION}-linux-x86_64.tar.gz -o /tmp/cmake.tar.gz && \
+    tar -xzf /tmp/cmake.tar.gz -C /opt/ && \
+    ln -s /opt/cmake-${CMAKE_VERSION}-linux-x86_64 /opt/cmake && \
+    rm /tmp/cmake.tar.gz
+
+# Add the new CMake to the PATH
+ENV PATH="/opt/cmake/bin:${PATH}"
+
+# Verify new CMake version
+RUN cmake --version
+    
+# --- Install GTSAM ---
+ARG GTSAM_VERSION="4.2.0"
+RUN git clone -b ${GTSAM_VERSION} https://github.com/borglab/gtsam.git /opt/gtsam && \
+    cd /opt/gtsam && \
+    mkdir build && cd build && \
+    cmake .. -DGTSAM_BUILD_EXAMPLES=OFF -DGTSAM_BUILD_TESTS=OFF -DGTSAM_USE_SYSTEM_EIGEN=ON && \
+    cd /opt/gtsam/build && \
+    make -j$(($(nproc) / 2 < 1 ? 1 : $(nproc) / 2)) && \
+    make install && \
+    rm -rf /opt/gtsam
+
+# --- Install Open3D ---
+ARG OPEN3D_VERSION="0.19.0"
+RUN git clone -b v${OPEN3D_VERSION} https://github.com/isl-org/Open3D.git /opt/Open3D && \
+    cd /opt/Open3D && ./util/install_deps_ubuntu.sh assume-yes && \
+    mkdir build && cd build && \
+    cmake .. -DBUILD_PYTHON_MODULE=OFF && \
+    make -j$(($(nproc) / 2 < 1 ? 1 : $(nproc) / 2)) && \
+    make install && \
+    rm -rf /opt/Open3D
+
+
+# --- Install matplotlibcpp ---
+RUN git clone https://github.com/lava/matplotlib-cpp.git /opt/matplotlib-cpp
+
+# --- Copy in MS-Mapping Source Code ---
+# Set the working directory
+WORKDIR /root/catkin_ws/src/ms_mapping
+
+# Copy your project source code into the Docker image
+COPY . .
+
+# Build the ROS workspace
+RUN /bin/bash -c "source /opt/ros/noetic/setup.bash && \
+    cd /root/catkin_ws && \
+    catkin_make"
+
+RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc && \
+    echo "if [ -f ~/catkin_ws/devel/setup.bash ]; then" >> ~/.bashrc && \
+    echo "  source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc && \
+    echo "fi" >> ~/.bashrc
+
+

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -98,4 +98,8 @@ RUN echo "source /opt/ros/noetic/setup.bash" >> ~/.bashrc && \
     echo "  source ~/catkin_ws/devel/setup.bash" >> ~/.bashrc && \
     echo "fi" >> ~/.bashrc
 
+# Include the custom environment setup script
+RUN echo "if [ -f /yride_env_setup/custom_env.sh ]; then" >> ~/.bashrc && \
+    echo "  source /yride_env_setup/custom_env.sh" >> ~/.bashrc && \
+    echo "fi" >> ~/.bashrc
 

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Allow local docker access to X server
+xhost +local:docker
+
+# Ensure access is revoked on script exit
+trap 'xhost -local:docker' EXIT
+
+# Run script in the directory of the script
+cd "$SCRIPT_DIR"
+
+docker compose -f compose.yaml up -d
+
+docker exec -it ms_mapping /bin/bash
+

--- a/ms_mapping/launch/ms.launch
+++ b/ms_mapping/launch/ms.launch
@@ -1,11 +1,11 @@
 <launch>
     <!-- set your data config -->
     <param name="config_directory" type="string" value="$(find ms_mapping)/config/"/>
-    <param name="save_directory" type="string" value="/home/xchu/data/pose_slam_prior_result/"/>
-    <param name="map_directory" type="string" value="/home/xchu/data/prior_map/PK01/"/>
+    <param name="save_directory" type="string" value="/root/catkin_ws/src/ms_mapping/data/pose_slam_prior_result/"/>
+    <param name="map_directory" type="string" value="/root/catkin_ws/src/ms_mapping/data/PK1_results/"/>
 
     <!--set your data bag path-->
-    <arg name="bag_path" default="/media/xchu/新加卷/HKUSTGZ-DATASET/2023-10-28-19-09-04-Parkinglot-RedBird02/Parkinglot-RedBird-2023-10-28-19-09-04.bag"/>
+    <arg name="bag_path" default="/root/catkin_ws/src/ms_mapping/bags/Parkinglot-RedBird-2023-10-28-19-09-04.bag"/>
 
     <arg name="sequence" default="PK1-RB2-TEST"/>
 


### PR DESCRIPTION
I created a folder for docker functionality. Hopefully it is useful as it took me a while to make it since I kept running into issues. The purpose of the .dockerignore file is to only add the important files to the build context  thus decreasing the size of the docker image. I also added a small script to run the docker container if people find it useful.