### PR TITLE
Feat: Add PCD to MGRS conversion service (/convert_mgrs)

### DIFF
--- a/ms_mapping/CMakeLists.txt
+++ b/ms_mapping/CMakeLists.txt
@@ -60,6 +60,16 @@ find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(GTSAM REQUIRED QUIET)
+find_package(GeographicLib REQUIRED)
+
+find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
+        PATH_SUFFIXES GeographicLib)
+set(GeographicLib_INCLUDE_DIRS ${GeographicLib_INCLUDE_DIR})
+
+find_library(GeographicLib_LIBRARIES
+        NAMES Geographic)
+
+add_definitions(${GeographicLib_DEFINITIONS})
 
 ###########################################################################
 # Find Boost
@@ -87,6 +97,7 @@ include_directories(
         ${YAML_CPP_INCLUDE_DIR}
         ${PYTHON_INCLUDE_DIRS}
         ${Open3D_INCLUDE_DIRS}
+        ${GeographicLib_INCLUDE_DIRS}
 )
 # link_libraries(-lxml2 yaml-cpp)
 
@@ -102,8 +113,9 @@ add_executable(ms_mapping
         src/cloud_process.cpp
         src/ms_mapping/ms_mapping.cpp
         src/ms_mapping/ms_mapping_node.cpp
+        src/ms_mapping/utm_to_mgrs_converter.cpp
         )
-target_link_libraries(ms_mapping ${catkin_LIBRARIES} ${Open3D_LIBRARIES} ${PCL_LIBRARIES} ${OpenMP_CXX_FLAGS} ${OpenCV_LIBS}  gtsam)
+target_link_libraries(ms_mapping ${catkin_LIBRARIES} ${Open3D_LIBRARIES} ${PCL_LIBRARIES} ${OpenMP_CXX_FLAGS} ${OpenCV_LIBS}  gtsam ${GeographicLib_LIBRARIES})
 
 
 

--- a/ms_mapping/include/base_type.cpp
+++ b/ms_mapping/include/base_type.cpp
@@ -376,6 +376,10 @@ vector<double> b_acc_cov_n;
 vector<double> extrinT;
 vector<double> extrinR;
 
+double map_origin_northing;
+double map_origin_easting;
+double map_origin_height;
+
 void LoadRosParams(ros::NodeHandle &nh)
 {
     t_body_sensor = Eigen::Vector3d::Identity();
@@ -478,4 +482,8 @@ void LoadRosParams(ros::NodeHandle &nh)
     nh.param<int>("pgo/historyKeyframeSearchNum", historyKeyframeSearchNum, 25);
     nh.param<double>("pgo/loopClosureFrequency", loopClosureFrequency, 5);
     nh.param<double>("pgo/loopFitnessScoreThreshold", loopFitnessScoreThreshold,  0.9);
+
+    nh.param<double>("common/Northing", map_origin_northing, 0.0);
+    nh.param<double>("common/Easting", map_origin_easting, 0.0);
+    nh.param<double>("common/ElipsoidHeight", map_origin_height, 0.0);
 }

--- a/ms_mapping/include/base_type.hpp
+++ b/ms_mapping/include/base_type.hpp
@@ -624,6 +624,10 @@ pcl::PointCloud<pcl::PointXYZ>::Ptr vector2pc(
 pcl::PointCloud<pcl::PointXYZ>::Ptr vector2pc2d(
         const std::vector<Pose6D> vectorPose6d);
 
+extern double map_origin_northing;
+extern double map_origin_easting;
+extern double map_origin_height;
+
 void LoadRosParams(ros::NodeHandle &nh);
 
 template<typename T>

--- a/ms_mapping/src/ms_mapping/ms_mapping.cpp
+++ b/ms_mapping/src/ms_mapping/ms_mapping.cpp
@@ -1152,6 +1152,21 @@ bool MSMapping::SaveMap(std_srvs::Empty::Request &req,
     return true;
 }
 
+bool MSMapping::ConvertMGRS(std_srvs::Empty::Request &req,
+                            std_srvs::Empty::Response &res)
+{
+    ROS_INFO("CONVERTING PCD TO MGRS...");
+    std::string input_pcd = saveDirectory + sequence + "/final_map_lidar.pcd";
+    std::string output_pcd = saveDirectory + sequence + "/final_map_lidar_mgrs.pcd";
+    bool success = convertPCDToMGRS(input_pcd, output_pcd, map_origin_northing, map_origin_easting, map_origin_height);
+    if (!success) {
+        ROS_ERROR("MGRS Conversion failed!");
+    } else {
+        ROS_INFO("MGRS Conversion successful.");
+    }
+    return true;
+}
+
 void MSMapping::PerformRSLoopClosure(void)
 {
     const int minKeyFrames = 1;

--- a/ms_mapping/src/ms_mapping/ms_mapping.h
+++ b/ms_mapping/src/ms_mapping/ms_mapping.h
@@ -3,6 +3,7 @@
 
 #include "../cloud_process.h"
 #include "../data_saver.h"
+#include "utm_to_mgrs_converter.h"
 
 using namespace gtsam;
 using namespace open3d;
@@ -14,6 +15,7 @@ public:
         {
                 LoadRosParams(nh);
                 srvSaveMap = nh.advertiseService("/save_map", &MSMapping::SaveMap, this);
+                srvConvertMGRS = nh.advertiseService("/convert_mgrs", &MSMapping::ConvertMGRS, this);
                 pubLaserCloudSurround =  nh.advertise<sensor_msgs::PointCloud2>("/current_cloud", 10);
                 pubLaserCloudCrop =  nh.advertise<sensor_msgs::PointCloud2>("/crop_cloud", 10);
                 pubOdomAftPGO = nh.advertise<nav_msgs::Odometry>("/pgo_odom", 100);
@@ -129,6 +131,8 @@ private:
 
         bool SaveMap(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
 
+        bool ConvertMGRS(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
+
         void LidarCallback(const sensor_msgs::PointCloud2ConstPtr &pc_msg_ptr);
 
         void OdometryCallback(const nav_msgs::OdometryConstPtr &odom_msg_ptr);
@@ -208,6 +212,7 @@ private:
         ros::Publisher pubColorclouds, pubSemanticClouds;
 
         ros::ServiceServer srvSaveMap;
+        ros::ServiceServer srvConvertMGRS;
 
         std::mutex mKF;
         std::mutex mutexLock;

--- a/ms_mapping/src/ms_mapping/utm_to_mgrs_converter.cpp
+++ b/ms_mapping/src/ms_mapping/utm_to_mgrs_converter.cpp
@@ -1,0 +1,98 @@
+#include "utm_to_mgrs_converter.h"
+#include <GeographicLib/MGRS.hpp>
+#include <GeographicLib/UTMUPS.hpp>
+#include <GeographicLib/Geoid.hpp>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <ros/ros.h>
+#include <iostream>
+
+GNSSStat convertUTM2MGRS(GNSSStat gnss_stat_utm, const MGRSPrecision precision) {
+    constexpr int GZD_ID_size = 5;  // size of header like "53SPU"
+
+    GNSSStat mgrs = gnss_stat_utm;
+    mgrs.coordinate_system = CoordinateSystem::MGRS;
+    try {
+        std::string mgrs_code;
+        GeographicLib::MGRS::Forward(
+                gnss_stat_utm.zone, gnss_stat_utm.northup, gnss_stat_utm.x, gnss_stat_utm.y, gnss_stat_utm.latitude, static_cast<int>(precision), mgrs_code);
+        mgrs.mgrs_zone = std::string(mgrs_code.substr(0, GZD_ID_size));
+        mgrs.x = std::stod(mgrs_code.substr(GZD_ID_size, static_cast<int>(precision))) *
+                 std::pow(10, static_cast<int>(MGRSPrecision::_1_METER) - static_cast<int>(precision));  // set unit as [m]
+        mgrs.y = std::stod(mgrs_code.substr(GZD_ID_size + static_cast<int>(precision), static_cast<int>(precision))) *
+                 std::pow(10, static_cast<int>(MGRSPrecision::_1_METER) - static_cast<int>(precision));  // set unit as [m]
+        mgrs.z = gnss_stat_utm.z;                                 // set unit as [m]
+    } catch (const GeographicLib::GeographicErr & err) {
+        ROS_ERROR_STREAM("Failed to convert from UTM to MGRS: " << err.what());
+    }
+    return mgrs;
+}
+
+bool convertPCDToMGRS(const std::string& input_file_path, const std::string& output_file_path, 
+                      double map_origin_northing, double map_origin_easting, double map_origin_height) {
+    pcl::PointCloud<pcl::PointXYZI>::Ptr inputCloud(new pcl::PointCloud<pcl::PointXYZI>);
+    if (pcl::io::loadPCDFile<pcl::PointXYZI>(input_file_path, *inputCloud) == -1) {
+        ROS_ERROR_STREAM("Couldn't read file " << input_file_path);
+        return false;
+    }
+
+    double counter = 0;
+    GNSSStat gnss_stat_utm;
+    GNSSStat gnss_stat_mgrs;
+
+    pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_mgrs(new pcl::PointCloud<pcl::PointXYZI>);
+    cloud_mgrs->width = inputCloud->width;
+    cloud_mgrs->height = inputCloud->height;
+    cloud_mgrs->is_dense = inputCloud->is_dense;
+
+    for (long unsigned int i = 0; i < inputCloud->points.size(); i++) {
+        pcl::PointXYZI point = inputCloud->points[i];
+
+        // convert local UTM to global UTM coordinates
+        gnss_stat_utm.x = point.x + map_origin_easting;
+        gnss_stat_utm.y = point.y + map_origin_northing;
+        gnss_stat_utm.z = point.z + map_origin_height;
+        gnss_stat_utm.coordinate_system = CoordinateSystem::UTM;
+        gnss_stat_utm.zone = 35;
+        gnss_stat_utm.northup = true;
+
+        // convert latitude and longitude from UTM
+        GeographicLib::UTMUPS::Reverse(gnss_stat_utm.zone, gnss_stat_utm.northup, gnss_stat_utm.x, gnss_stat_utm.y, gnss_stat_utm.latitude, gnss_stat_utm.longitude);
+
+        gnss_stat_utm.altitude = gnss_stat_utm.z;
+
+        // convert height from ellipsoid to orthometric
+        double OrthometricHeight{0.0};
+        try {
+            GeographicLib::Geoid egm2008("egm2008-1");
+            OrthometricHeight = egm2008.ConvertHeight(
+                    gnss_stat_utm.latitude, gnss_stat_utm.longitude, gnss_stat_utm.altitude,
+                    GeographicLib::Geoid::ELLIPSOIDTOGEOID);
+        } catch (const GeographicLib::GeographicErr & err) {
+            OrthometricHeight = gnss_stat_utm.altitude;
+        }
+
+        // convert global UTM to MGRS
+        gnss_stat_mgrs = convertUTM2MGRS(gnss_stat_utm, MGRSPrecision::_100MICRO_METER);
+
+        //create new pointcloud with mgrs coordinates
+        pcl::PointXYZI point_mgrs;
+        point_mgrs.x = gnss_stat_mgrs.x;
+        point_mgrs.y = gnss_stat_mgrs.y;
+        point_mgrs.z = OrthometricHeight;
+        point_mgrs.intensity = point.intensity;
+        cloud_mgrs->points.push_back(std::move(point_mgrs));
+
+        if (counter == 1000000) {
+            ROS_INFO("continue.");
+            counter = 0;
+        }
+        counter++;
+    }
+
+    //save pcd file
+    pcl::io::savePCDFileASCII(output_file_path, *cloud_mgrs);
+    ROS_INFO_STREAM("Saved " << cloud_mgrs->points.size() << " data points to " << output_file_path);
+    return true;
+}

--- a/ms_mapping/src/ms_mapping/utm_to_mgrs_converter.h
+++ b/ms_mapping/src/ms_mapping/utm_to_mgrs_converter.h
@@ -1,0 +1,46 @@
+#ifndef MS_MAPPING_UTM_TO_MGRS_CONVERTER_H
+#define MS_MAPPING_UTM_TO_MGRS_CONVERTER_H
+
+#include <string>
+
+enum class MGRSPrecision {
+    _1_METER = 5,
+    _100MICRO_METER = 9,
+};
+
+enum class CoordinateSystem {
+    UTM = 0,
+    MGRS = 1,
+};
+
+struct GNSSStat {
+    GNSSStat()
+        : coordinate_system(CoordinateSystem::MGRS),
+          northup(true),
+          zone(0),
+          mgrs_zone(""),
+          x(0),
+          y(0),
+          z(0),
+          latitude(0),
+          longitude(0),
+          altitude(0) {}
+
+    CoordinateSystem coordinate_system;
+    bool northup;
+    int zone;
+    std::string mgrs_zone;
+    double x;
+    double y;
+    double z;
+    double latitude;
+    double longitude;
+    double altitude;
+};
+
+GNSSStat convertUTM2MGRS(GNSSStat gnss_stat_utm, const MGRSPrecision precision);
+
+bool convertPCDToMGRS(const std::string& input_file_path, const std::string& output_file_path, 
+                      double map_origin_northing, double map_origin_easting, double map_origin_height);
+
+#endif // MS_MAPPING_UTM_TO_MGRS_CONVERTER_H


### PR DESCRIPTION
**Overview** This PR introduces a new ROS service to convert the final generated Point Cloud Data (PCD) map from local UTM coordinates to the Military Grid Reference System (MGRS).

Key Changes

- New ROS Service (/convert_mgrs): Added a service in MSMapping that triggers the conversion of final_map_lidar.pcd and outputs the result as final_map_lidar_mgrs.pcd.

- Coordinate Conversion Module: Introduced utm_to_mgrs_converter.cpp/h to handle robust transformations using GeographicLib.

- Accurate Altitude Adjustments: Integrated GeographicLib::Geoid (egm2008-1) to convert heights from ellipsoid to orthometric during the transformation process.

- Point-by-Point Processing: The converter reads the input PCD file, translates local UTM points to global UTM (using map origin offsets), calculates latitude/longitude, and converts them down to high-precision MGRS coordinates.

Credits: https://github.com/leo-drive/pc_utm_to_mgrs_converter